### PR TITLE
Don't raise if a struct field does not exist

### DIFF
--- a/lib/diff/patch.ex
+++ b/lib/diff/patch.ex
@@ -35,7 +35,7 @@ defmodule ExAudit.Patch do
         Map.delete(map, key)
 
       {key, {:changed, changes}}, map ->
-        Map.update!(map, key, &patch(&1, changes))
+        Map.update(map, key, nil, &patch(&1, changes))
     end)
   end
 end


### PR DESCRIPTION
This allows us to patch old versions of a struct which has been migrated to add new fields