### PR TITLE
Avoid crash when updating a `nil` map

### DIFF
--- a/lib/diff/patch.ex
+++ b/lib/diff/patch.ex
@@ -2,40 +2,32 @@ defmodule ExAudit.Patch do
   @doc """
   Applies the patch to the given term
   """
-  def patch(_, {:primitive_change, _, b}) do
-    b
-  end
-
-  def patch(a, :not_changed) do
-    a
-  end
+  def patch(_, {:primitive_change, _, value}), do: value
+  def patch(value, :not_changed), do: value
 
   def patch(list, changes) when is_list(list) and is_list(changes) do
     changes
     |> Enum.reverse()
     |> Enum.reduce(list, fn
-      {:added_to_list, i, el}, list ->
-        List.insert_at(list, i, el)
-
-      {:removed_from_list, i, _}, list ->
-        List.delete_at(list, i)
-
-      {:changed_in_list, i, change}, list ->
-        List.update_at(list, i, &patch(&1, change))
+      {:added_to_list, i, el}, list -> List.insert_at(list, i, el)
+      {:removed_from_list, i, _}, list -> List.delete_at(list, i)
+      {:changed_in_list, i, change}, list -> List.update_at(list, i, &patch(&1, change))
     end)
   end
 
   def patch(map, changes) when is_map(map) and is_map(changes) do
-    changes
-    |> Enum.reduce(map, fn
-      {key, {:added, b}}, map ->
-        Map.put(map, key, b)
+    Enum.reduce(changes, map, fn
+      {key, {:added, value}}, map -> Map.put(map, key, value)
+      {key, {:removed, _}}, map -> Map.delete(map, key)
+      {key, {:changed, changes}}, map -> Map.update(map, key, nil, &patch(&1, changes))
+    end)
+  end
 
-      {key, {:removed, _}}, map ->
-        Map.delete(map, key)
-
-      {key, {:changed, changes}}, map ->
-        Map.update(map, key, nil, &patch(&1, changes))
+  def patch(nil, changes) when is_map(changes) do
+    Enum.reduce(changes, %{}, fn
+      {key, {:added, value}}, map -> Map.put(map, key, value)
+      {key, {:removed, _}}, map -> Map.delete(map, key)
+      {key, {:changed, changes}}, map -> Map.put(map, key, patch(map, changes))
     end)
   end
 end


### PR DESCRIPTION
A struct has changes including `{:added, nil}` to a key which is expected to be a map. Later, we get a `{:changed, changes}` update which causes a crash because we recursively `patch(nil, changes)` and there's no clause handling `(nil, map())`.

This adds that clause.